### PR TITLE
Ignore non-file objects in sync_items()

### DIFF
--- a/src/vfs/file.rs
+++ b/src/vfs/file.rs
@@ -704,6 +704,9 @@ impl DiskCache {
                 if item.folder.is_some() {
                     continue;
                 }
+                if item.file.is_none() {
+                    continue;
+                }
 
                 let id = item.id.clone().expect("Missing id");
                 let file = match cache.get_mut(&id) {

--- a/src/vfs/inode.rs
+++ b/src/vfs/inode.rs
@@ -213,6 +213,7 @@ impl InodePool {
         DriveItemField::deleted,
         // InodeAttr.
         DriveItemField::size,
+        DriveItemField::file,
         DriveItemField::file_system_info,
         DriveItemField::folder,
     ];
@@ -457,6 +458,9 @@ impl InodePool {
         let mut dir_marked_deleted = HashSet::new();
 
         for item in updated {
+            if !(item.file.is_some() || item.folder.is_some()) {
+                continue;
+            }
             let item_id = item.id.as_ref().expect("Missing id");
 
             // Remove an existing item.


### PR DESCRIPTION
Fix #6.

<https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http>:

> Download the contents of the primary stream (file) of a [driveItem](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0). Only **driveItems** with the **file** property can be downloaded.

And the OneNote "files" causing problems here are neither "folder" nor "file" here. The easiest workaround is to just ignore them in VFS module.